### PR TITLE
Add ros2 launch example

### DIFF
--- a/ap_custom_services/package.xml
+++ b/ap_custom_services/package.xml
@@ -13,6 +13,7 @@
   <member_of_group>rosidl_interface_packages</member_of_group>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <exec_depend>ros2launch</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ap_std_msg_subscribers/CMakeLists.txt
+++ b/ap_std_msg_subscribers/CMakeLists.txt
@@ -1,0 +1,91 @@
+cmake_minimum_required(VERSION 3.5)
+project(ap_std_msg_subscribers)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_executable(bool_listener src/APBoolSubscriber.cpp)
+ament_target_dependencies(bool_listener rclcpp std_msgs)
+
+add_executable(byte_listener src/APByteSubscriber.cpp)
+ament_target_dependencies(byte_listener rclcpp std_msgs)
+
+add_executable(char_listener src/APCharSubscriber.cpp)
+ament_target_dependencies(char_listener rclcpp std_msgs)
+
+add_executable(int8_listener src/APInt8Subscriber.cpp)
+ament_target_dependencies(int8_listener rclcpp std_msgs)
+
+add_executable(uint8_listener src/APUInt8Subscriber.cpp)
+ament_target_dependencies(uint8_listener rclcpp std_msgs)
+
+add_executable(int16_listener src/APInt16Subscriber.cpp)
+ament_target_dependencies(int16_listener rclcpp std_msgs)
+
+add_executable(uint16_listener src/APUInt16Subscriber.cpp)
+ament_target_dependencies(uint16_listener rclcpp std_msgs)
+
+add_executable(int32_listener src/APInt32Subscriber.cpp)
+ament_target_dependencies(int32_listener rclcpp std_msgs)
+
+add_executable(uint32_listener src/APUInt32Subscriber.cpp)
+ament_target_dependencies(uint32_listener rclcpp std_msgs)
+
+add_executable(int64_listener src/APInt64Subscriber.cpp)
+ament_target_dependencies(int64_listener rclcpp std_msgs)
+
+add_executable(uint64_listener src/APUInt64Subscriber.cpp)
+ament_target_dependencies(uint64_listener rclcpp std_msgs)
+                                    
+add_executable(float32_listener src/APFloat32Subscriber.cpp)
+ament_target_dependencies(float32_listener rclcpp std_msgs)
+
+add_executable(float64_listener src/APFloat64Subscriber.cpp)
+ament_target_dependencies(float64_listener rclcpp std_msgs)
+
+add_executable(string_listener src/APStringSubscriber.cpp)
+ament_target_dependencies(string_listener rclcpp std_msgs)
+
+add_executable(time_listener src/APTimeSubscriber.cpp)
+ament_target_dependencies(time_listener rclcpp std_msgs)
+
+install(TARGETS
+  bool_listener
+  byte_listener
+  int8_listener
+  uint8_listener
+  int16_listener
+  uint16_listener
+  int32_listener
+  uint32_listener
+  int64_listener
+  uint64_listener
+  float32_listener
+  float64_listener
+  char_listener
+  string_listener
+  time_listener
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/ap_std_msg_subscribers/CMakeLists.txt
+++ b/ap_std_msg_subscribers/CMakeLists.txt
@@ -81,7 +81,13 @@ install(TARGETS
   char_listener
   string_listener
   time_listener
-  DESTINATION lib/${PROJECT_NAME})
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/ap_std_msg_subscribers/launch/ci_test.launch.py
+++ b/ap_std_msg_subscribers/launch/ci_test.launch.py
@@ -1,0 +1,15 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+
+    time_listener = Node(
+        package="ap_std_msg_subscribers",
+        namespace="",
+        executable="time_listener",
+        name="time_listener",
+        output="both",
+    )
+
+    return LaunchDescription([time_listener])

--- a/ap_std_msg_subscribers/src/APTimeSubscriber.cpp
+++ b/ap_std_msg_subscribers/src/APTimeSubscriber.cpp
@@ -1,0 +1,39 @@
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+// #include "std_msgs/msg/Time.hpp"
+
+using std::placeholders::_1;
+
+class APTimeSubscriber : public rclcpp::Node
+{
+  public:
+    APTimeSubscriber()
+    : Node("ap_time_subscriber")
+    {
+      subscription_ = this->create_subscription<builtin_interfaces::msg::Time>(
+      "ROS2_Time", 10, std::bind(
+          &APTimeSubscriber::topic_callback, this, _1));
+    }
+
+  private:
+    void topic_callback(
+          const builtin_interfaces::msg::Time::SharedPtr msg) const
+    {
+      if (msg->sec) {
+        RCLCPP_INFO(this->get_logger(), "From AP : True");
+      } else {
+        RCLCPP_INFO(this->get_logger(), "From AP : False");
+      }
+    }
+    rclcpp::Subscription<builtin_interfaces::msg::Time>::SharedPtr
+        subscription_;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<APTimeSubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Add a simple ros2 launch example for the time_listener node from #2.

- Add launch file.
- Update CMakeLists.txt to install launch folder.


## Test

```bash
% ros2 launch ap_std_msg_subscribers ci_test.launch.py
[INFO] [launch]: All log files can be found below /Users/rhys/.ros/log/2023-03-08-12-59-03-505442-MacPro2.local-24245
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [time_listener-1]: process started with pid [24246]
[time_listener-1] [INFO] [1678280344.450270268] [time_listener]: From AP : True
[time_listener-1] [INFO] [1678280344.469194993] [time_listener]: From AP : True
[time_listener-1] [INFO] [1678280344.488582647] [time_listener]: From AP : True
[time_listener-1] [INFO] [1678280344.507639168] [time_listener]: From AP : True
[time_listener-1] [INFO] [1678280344.526670845] [time_listener]: From AP : True
``` 